### PR TITLE
style<machine.Timer>: small language typo

### DIFF
--- a/docs/en/library/micropython/machine/machine.Timer.rst
+++ b/docs/en/library/micropython/machine/machine.Timer.rst
@@ -7,7 +7,7 @@ Class Timer -- Hardware Control Timer
 Timer for hardware processing cycle and event time. Timers are probably the most flexible and heterogeneous hardware types in MCUs and SoCs, and vary greatly from one model to another. 
 MicroPython's Timer class defines a baseline operation that performs callbacks within a given time period (or executes a callback after a delay), and allows a specific board to define more non-standard behaviors (so it cannot be ported to other boards). 
 
-Reference for the timer callback :ref:`重要约束 <machine_callbacks>` 。
+Reference for the timer callback :ref:`important constraints <machine_callbacks>`.
 
 .. note::
 


### PR DESCRIPTION
- modified Chinese into English.

I think it is weird that an English document suddenly shows a Chinese ref.

I am not sure whether it works. Do you think it is necessary to make such a tiny change?